### PR TITLE
Refactor SegmentationModel to support Cellpose-SAM v4.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 license = { file = "LICENSE" }
 dependencies = [
+    "cellpose>=4.0.6",
     "nd2>=0.10.3",
     "numpy<2.1",
     "pytest>=8.4.1",

--- a/src/arcadia_microscopy_tools/batch.py
+++ b/src/arcadia_microscopy_tools/batch.py
@@ -309,8 +309,8 @@ class ImageBatch:
         if isinstance(channel, str):
             channel = Channel[channel]
 
-        # Extract pre-processed intensities
-        batch_intensities = self.processed_intensities_dict[channel].copy()
+        # Get processed intensities as a list to pass to Cellpose
+        batch_intensities = [frame for frame in self.processed_intensities_dict[channel]]
         # Run Cellpose
         masks = model.run(batch_intensities, self.batch_size, **cellpose_kwargs)
         self.segmentation_masks_dict[channel] = masks

--- a/src/arcadia_microscopy_tools/model.py
+++ b/src/arcadia_microscopy_tools/model.py
@@ -1,5 +1,6 @@
 import logging
 from dataclasses import dataclass, field
+from typing import Any
 
 import numpy as np
 import torch
@@ -105,7 +106,7 @@ class SegmentationModel:
         self,
         batch_intensities: FloatArray,
         batch_size: int = 16,
-        **cellpose_kwargs,
+        **cellpose_kwargs: dict[str, Any],
     ) -> IntArray:
         """Run cell segmentation using Cellpose.
 

--- a/src/arcadia_microscopy_tools/model.py
+++ b/src/arcadia_microscopy_tools/model.py
@@ -3,56 +3,86 @@ from dataclasses import dataclass, field
 
 import numpy as np
 import torch
-from cellpose.denoise import CellposeDenoiseModel
+from cellpose.models import CellposeModel
 
-from .typing import FloatArray, IntArray, ScalarArray
+from .typing import FloatArray, IntArray
 
 logger = logging.getLogger(__name__)
 
 
 @dataclass
 class SegmentationModel:
-    """Cell segmentation model based on Cellpose.
+    """CellposeModel wrapper class to facilitate high-throughput cell segmentation.
 
-    This class wraps the Cellpose deep learning model for cell segmentation,
+    This class wraps the Cellpose-SAM deep learning model for cell segmentation,
     providing a simplified interface for batch processing of microscopy images.
 
     Attributes:
-        model_type: Cellpose model type (e.g. "cyto3", "nuclei").
-        restore_type: Type of restoration/denoising to apply.
-        batch_size: Number of images to process simultaneously.
-        channels: List with two elements for cytoplasm and nucleus channels.
-        diameter: Expected cell diameter in pixels.
-        do_3D: Whether to use 3D segmentation.
+        cell_diameter_px: Expected cell diameter in pixels. Used as `diameter` parameter
+            for Cellpose evaluation. Default is 30 pixels.
+        flow_threshold: Flow error threshold for mask generation. Higher values result
+            in fewer masks. Must be >= 0. Default is 0.4.
+        cellprob_threshold: Cell probability threshold for mask generation. Higher values
+            result in fewer and more confident masks. Must be between -10 and 10. Default is 0.
+        num_iterations: Number of iterations for segmentation algorithm. If None, uses
+            Cellpose default. Default is None.
+        device: PyTorch device for model computation. If None, automatically selects
+            the best available device (CUDA > MPS > CPU).
+
+    Notes:
+        - Channels are no longer an input in Cellpose v4.x (Cellpose-SAM). The model will use the
+          first 3 channels of the input image and truncate the rest. It is also (allegedly)
+          channel-invariant -- order of channels in the image shouldn't matter.
+        - Cellpose-SAM has been trained on images with ROI diameters from size 7.5 to 120, with a
+          mean diameter of 30 pixels, such that it should be fairly robust to different cell sizes.
+
+    See also:
+        - https://cellpose.readthedocs.io/en/latest/settings.html#settings
     """
 
-    model_type: str = "cyto3"
-    restore_type: str = "denoise_cyto3"
-    batch_size: int = 8
-    channels: list[int] = field(default_factory=lambda: [0, 0])
-    diameter: int = 10
-    do_3D: bool = False
-    _model: CellposeDenoiseModel | None = None
+    cell_diameter_px: int = 30
+    flow_threshold: float = 0.4
+    cellprob_threshold: float = 0
+    num_iterations: int = None
+    device: torch.device = field(default=None)
+    _model: CellposeModel = field(default=None, init=False, repr=False)
 
     def __post_init__(self):
         """Validate parameters after initialization."""
-        if not isinstance(self.channels, list) or len(self.channels) != 2:
-            raise ValueError("channels must be a list with exactly 2 elements")
+        if self.cell_diameter_px <= 0:
+            raise ValueError(f"Cell diameter [px] must be positive, got {self.cell_diameter_px}")
 
-        if self.diameter <= 0:
-            raise ValueError("diameter must be positive")
+        if self.flow_threshold < 0:
+            raise ValueError(f"Flow threshold must be non-negative, got {self.flow_threshold}")
 
-        if self.batch_size <= 0:
-            raise ValueError("batch_size must be positive")
+        if not (-10 <= self.cellprob_threshold <= 10):
+            raise ValueError(
+                "Cell probability threshold must be between -10 and 10, "
+                f"got {self.cellprob_threshold}"
+            )
+
+        if self.device is None:
+            self.device = self.find_best_available_device()
 
     @property
-    def device(self) -> torch.device:
-        """Get appropriate compute device (CPU, CUDA GPU, or Apple Metal).
+    def cellpose_model(self) -> CellposeModel:
+        """Lazy-load and cache the Cellpose model."""
+        if self._model is None:
+            logger.info(f"Loading Cellpose-SAM model on {self.device}")
+            try:
+                self._model = CellposeModel(device=self.device)
+            except Exception as e:
+                logger.error(f"Failed to load Cellpose model: {e}")
+                raise RuntimeError from e
+        return self._model
+
+    def find_best_available_device(self) -> torch.device:
+        """Get appropriate compute device (CUDA GPU, Apple Metal, or CPU).
 
         Determines the best available device for running the segmentation model:
-        1. CUDA GPU if available (NVIDIA GPUs)
-        2. MPS (Metal Performance Shaders) if available (Apple Silicon/AMD GPUs on macOS)
-        3. CPU as fallback
+            1. CUDA GPU if available (NVIDIA GPUs)
+            2. MPS (Metal Performance Shaders) if available (Apple Silicon/AMD GPUs on macOS)
+            3. CPU as fallback
 
         Returns:
             torch.device: The selected compute device.
@@ -69,70 +99,47 @@ class SegmentationModel:
             device = torch.device("cpu")
             cpu_count = torch.get_num_threads()
             logger.info(f"No GPU acceleration available. Using CPU with {cpu_count} threads.")
-
         return device
 
-    @property
-    def cellpose_model(self) -> CellposeDenoiseModel:
-        """Lazy-load and cache the Cellpose model."""
-        if self._model is None:
-            logger.info(f"Loading {self.model_type} model with {self.restore_type} restoration.")
-            try:
-                self._model = CellposeDenoiseModel(
-                    model_type=self.model_type,
-                    restore_type=self.restore_type,
-                    device=self.device,
-                )
-            except Exception as e:
-                logger.error(f"Failed to load Cellpose model: {e}")
-                raise
-
-        return self._model
-
-    def run_cellpose(
+    def run(
         self,
-        array: FloatArray,
-        return_all: bool = False,
-        **kwargs,
-    ) -> IntArray | tuple[IntArray, ScalarArray, ScalarArray, ScalarArray]:
+        batch_intensities: FloatArray,
+        batch_size: int = 16,
+        **cellpose_kwargs,
+    ) -> IntArray:
         """Run cell segmentation using Cellpose.
 
         Args:
-            array: Input image array with shape [batch, height, width].
-            return_all: If True, return masks, flows, styles, and images; otherwise just masks.
-            **kwargs: Additional keyword arguments passed to Cellpose model.eval().
+            batch_intensities: Input batch of image intensities with shape (batch, height, width).
+                Intensity values should be normalized floats, typically in range [0, 1].
+            batch_size: Number of images to process simultaneously. Larger values use more
+                memory but may be faster. Default is 16.
+            **cellpose_kwargs: Additional keyword arguments passed to CellposeModel.eval().
+                Common options include 'min_size' (minimum cell size in pixels).
 
         Returns:
-            If return_all=False:
-                IntArray: Labeled cell masks where each distinct cell has a unique integer ID
-            If return_all=True:
-                Tuple containing:
-                - masks: Labeled cell masks
-                - flows: Flow fields used for segmentation
-                - styles: Style vectors
-                - imgs: Processed input images
+            IntArray: Output batch of labeled masks with shape (batch, height, width).
+                Each segmented cell has a unique positive integer ID, background is 0.
 
         Raises:
-            RuntimeError: If the Cellpose model fails during segmentation
+            RuntimeError: If the Cellpose model fails during segmentation.
+
+        See also:
+            - For full list of optional cellpose_kwargs, see:
+              https://cellpose.readthedocs.io/en/latest/api.html#id0
         """
         try:
-            masks, flows, styles, imgs = self.cellpose_model.eval(
-                x=array,
-                batch_size=self.batch_size,
-                channels=self.channels,
-                diameter=self.diameter,
-                do_3D=self.do_3D,
-                **kwargs,
+            masks_uint16, _flows, _styles, _imgs = self.cellpose_model.eval(
+                x=batch_intensities,
+                batch_size=batch_size,
+                diameter=self.cell_diameter_px,
+                flow_threshold=self.flow_threshold,
+                cellprob_threshold=self.cellprob_threshold,
+                niter=self.num_iterations,
+                **cellpose_kwargs,
             )
-
-            # Convert to int64 for consistency
-            masks = masks.astype(np.int64)
-
-            if return_all:
-                return masks, flows, styles, imgs
-            else:
-                return masks
-
         except Exception as e:
             logger.error(f"Cellpose segmentation failed: {e}")
-            raise RuntimeError(f"Cellpose segmentation failed: {e}") from e
+            raise RuntimeError from e
+
+        return masks_uint16.astype(np.int64)

--- a/src/arcadia_microscopy_tools/model.py
+++ b/src/arcadia_microscopy_tools/model.py
@@ -143,4 +143,4 @@ class SegmentationModel:
             logger.error(f"Cellpose segmentation failed: {e}")
             raise RuntimeError from e
 
-        return masks_uint16.astype(np.int64)
+        return np.array(masks_uint16, dtype=np.int64)

--- a/src/arcadia_microscopy_tools/model.py
+++ b/src/arcadia_microscopy_tools/model.py
@@ -130,7 +130,7 @@ class SegmentationModel:
               https://cellpose.readthedocs.io/en/latest/api.html#id0
         """
         try:
-            masks_uint16, _flows, _styles, _imgs = self.cellpose_model.eval(
+            masks_uint16, *_ = self.cellpose_model.eval(
                 x=batch_intensities,
                 batch_size=batch_size,
                 diameter=self.cell_diameter_px,

--- a/src/arcadia_microscopy_tools/tests/test_model.py
+++ b/src/arcadia_microscopy_tools/tests/test_model.py
@@ -1,0 +1,203 @@
+from unittest.mock import Mock, patch
+
+import numpy as np
+import pytest
+import torch
+
+from arcadia_microscopy_tools.model import SegmentationModel
+
+
+class TestSegmentationModel:
+    """Test suite for SegmentationModel class."""
+
+    def test_default_initialization(self):
+        """Test that model initializes with correct default values."""
+        model = SegmentationModel()
+
+        assert model.cell_diameter_px == 30
+        assert model.flow_threshold == 0.4
+        assert model.cellprob_threshold == 0
+        assert model.num_iterations is None
+        assert model.device is not None  # Should be auto-assigned
+        assert model._model is None
+
+    def test_custom_initialization(self):
+        """Test that model initializes with custom values."""
+        device = torch.device("cpu")
+        model = SegmentationModel(
+            cell_diameter_px=25,
+            flow_threshold=0.5,
+            cellprob_threshold=-2.0,
+            num_iterations=10,
+            device=device,
+        )
+
+        assert model.cell_diameter_px == 25
+        assert model.flow_threshold == 0.5
+        assert model.cellprob_threshold == -2.0
+        assert model.num_iterations == 10
+        assert model.device == device
+
+    def test_cell_diameter_validation(self):
+        """Test validation of cell_diameter_px parameter."""
+        with pytest.raises(ValueError, match="Cell diameter.*"):
+            SegmentationModel(cell_diameter_px=0)
+
+        with pytest.raises(ValueError, match="Cell diameter.*"):
+            SegmentationModel(cell_diameter_px=-5)
+
+    def test_flow_threshold_validation(self):
+        """Test validation of flow_threshold parameter."""
+        with pytest.raises(ValueError, match="Flow threshold.*"):
+            SegmentationModel(flow_threshold=-0.1)
+
+        # Valid values should not raise
+        SegmentationModel(flow_threshold=0.0)
+        SegmentationModel(flow_threshold=1.0)
+
+    def test_cellprob_threshold_validation(self):
+        """Test validation of cellprob_threshold parameter."""
+        with pytest.raises(ValueError, match="Cell probability threshold.*"):
+            SegmentationModel(cellprob_threshold=-11)
+
+        with pytest.raises(ValueError, match="Cell probability threshold.*"):
+            SegmentationModel(cellprob_threshold=11)
+
+        # Valid values should not raise
+        SegmentationModel(cellprob_threshold=-10)
+        SegmentationModel(cellprob_threshold=10)
+        SegmentationModel(cellprob_threshold=0)
+
+    @patch("torch.cuda.is_available")
+    @patch("torch.cuda.get_device_name")
+    @patch("torch.cuda.get_device_properties")
+    def test_find_best_device_cuda(self, mock_props, mock_name, mock_cuda):
+        """Test device selection when CUDA is available."""
+        mock_cuda.return_value = True
+        mock_name.return_value = "NVIDIA RTX 3080"
+        mock_props.return_value = Mock(total_memory=10737418240)  # 10GB
+
+        model = SegmentationModel()
+        device = model.find_best_available_device()
+
+        assert device.type == "cuda"
+
+    @patch("torch.cuda.is_available")
+    @patch("torch.backends.mps.is_available")
+    def test_find_best_device_mps(self, mock_mps, mock_cuda):
+        """Test device selection when MPS is available but CUDA is not."""
+        mock_cuda.return_value = False
+        mock_mps.return_value = True
+
+        model = SegmentationModel()
+        device = model.find_best_available_device()
+
+        assert device.type == "mps"
+
+    @patch("torch.cuda.is_available")
+    @patch("torch.backends.mps.is_available")
+    @patch("torch.get_num_threads")
+    def test_find_best_device_cpu(self, mock_threads, mock_mps, mock_cuda):
+        """Test device selection when only CPU is available."""
+        mock_cuda.return_value = False
+        mock_mps.return_value = False
+        mock_threads.return_value = 8
+
+        model = SegmentationModel()
+        device = model.find_best_available_device()
+
+        assert device.type == "cpu"
+
+    @patch("arcadia_microscopy_tools.model.CellposeModel")
+    def test_cellpose_model_caching(self, mock_cellpose_class):
+        """Test that cellpose model is cached after first access."""
+        mock_model = Mock()
+        mock_cellpose_class.return_value = mock_model
+
+        model = SegmentationModel()
+
+        # First access should create model
+        result1 = model.cellpose_model
+        assert result1 == mock_model
+        assert mock_cellpose_class.call_count == 1
+
+        # Second access should return cached model
+        result2 = model.cellpose_model
+        assert result2 == mock_model
+        assert mock_cellpose_class.call_count == 1  # Still only called once
+
+    @patch("arcadia_microscopy_tools.model.CellposeModel")
+    def test_cellpose_model_error_handling(self, mock_cellpose_class):
+        """Test error handling in cellpose model loading."""
+        mock_cellpose_class.side_effect = Exception("Model loading failed")
+
+        model = SegmentationModel()
+
+        with pytest.raises(RuntimeError):
+            _ = model.cellpose_model
+
+    @patch("arcadia_microscopy_tools.model.CellposeModel")
+    def test_run_method(self, mock_cellpose_class):
+        """Test the run method with mocked Cellpose model."""
+        # Setup mock
+        mock_model = Mock()
+        mock_masks = np.array([[[1, 2], [3, 0]], [[0, 1], [2, 3]]], dtype=np.uint16)
+        mock_flows = np.zeros((2, 2, 2, 2))
+        mock_styles = np.zeros((2, 256))
+        mock_imgs = np.zeros((2, 2, 2))
+
+        mock_model.eval.return_value = (mock_masks, mock_flows, mock_styles, mock_imgs)
+        mock_cellpose_class.return_value = mock_model
+
+        # Create model and test data
+        model = SegmentationModel(cell_diameter_px=25, flow_threshold=0.3, cellprob_threshold=-1)
+        batch_data = np.random.rand(2, 256, 256).astype(np.float32)
+
+        # Run segmentation
+        result = model.run(batch_data, batch_size=8, min_size=100)
+
+        # Verify results
+        assert isinstance(result, np.ndarray)
+        assert result.dtype == np.int64
+        np.testing.assert_array_equal(result, mock_masks.astype(np.int64))
+
+        # Verify Cellpose was called with correct parameters
+        mock_model.eval.assert_called_once_with(
+            x=batch_data,
+            batch_size=8,
+            diameter=25,
+            flow_threshold=0.3,
+            cellprob_threshold=-1,
+            niter=None,
+            min_size=100,
+        )
+
+    @patch("arcadia_microscopy_tools.model.CellposeModel")
+    def test_run_method_error_handling(self, mock_cellpose_class):
+        """Test error handling in run method."""
+        mock_model = Mock()
+        mock_model.eval.side_effect = Exception("Segmentation failed")
+        mock_cellpose_class.return_value = mock_model
+
+        model = SegmentationModel()
+        batch_data = np.random.rand(1, 100, 100).astype(np.float32)
+
+        with pytest.raises(RuntimeError):
+            model.run(batch_data)
+
+    @patch("arcadia_microscopy_tools.model.CellposeModel")
+    def test_run_with_iterations(self, mock_cellpose_class):
+        """Test run method with num_iterations parameter."""
+        mock_model = Mock()
+        mock_masks = np.array([[[1, 0], [0, 2]]], dtype=np.uint16)
+        mock_model.eval.return_value = (mock_masks, None, None, None)
+        mock_cellpose_class.return_value = mock_model
+
+        model = SegmentationModel(num_iterations=5)
+        batch_data = np.random.rand(1, 50, 50).astype(np.float32)
+
+        model.run(batch_data)
+
+        # Verify niter parameter was passed correctly
+        call_args = mock_model.eval.call_args
+        assert call_args.kwargs["niter"] == 5

--- a/uv.lock
+++ b/uv.lock
@@ -42,6 +42,7 @@ name = "arcadia-microscopy-tools"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "cellpose" },
     { name = "nd2" },
     { name = "numpy" },
     { name = "pytest" },
@@ -62,6 +63,7 @@ lint = [
 
 [package.metadata]
 requires-dist = [
+    { name = "cellpose", specifier = ">=4.0.6" },
     { name = "nd2", specifier = ">=0.10.3" },
     { name = "numpy", specifier = "<2.1" },
     { name = "pytest", specifier = ">=8.4.1" },
@@ -226,6 +228,30 @@ wheels = [
 [package.optional-dependencies]
 css = [
     { name = "tinycss2" },
+]
+
+[[package]]
+name = "cellpose"
+version = "4.0.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fastremap" },
+    { name = "fill-voids" },
+    { name = "imagecodecs" },
+    { name = "natsort" },
+    { name = "numpy" },
+    { name = "opencv-python-headless" },
+    { name = "roifile" },
+    { name = "scipy" },
+    { name = "segment-anything" },
+    { name = "tifffile" },
+    { name = "torch" },
+    { name = "torchvision" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/56/b7/ea43df845a6ffe0b5de8ffed7420498057589d3cdada92858bf9a17e5d38/cellpose-4.0.6.tar.gz", hash = "sha256:df12786f6e58118e7ab76e8857c3167567601f48ea852d316a36402104e27273", size = 4249238 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/3a/26159bc4e5cc8e1cd7dae3ee95e9ef2d4178835157b4cba1881cca87a8cc/cellpose-4.0.6-py3-none-any.whl", hash = "sha256:bf79e98261d7c6a9bdbd9494283125cc4ac930f2ffa6d86c147f4b8fcb6ac9e8", size = 212254 },
 ]
 
 [[package]]
@@ -421,12 +447,58 @@ wheels = [
 ]
 
 [[package]]
+name = "fastremap"
+version = "1.17.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/42/cb3cea95988d31a2f3bd15c3cca6cdc5562a57a9bef20039513aeecce5c3/fastremap-1.17.2.tar.gz", hash = "sha256:35a76722fac6b38ef6416662119084e22130ec25fcbb04134b51cc54733b6033", size = 49599 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/e6/417a988dde22659fdfb23ae474ab0c81bcfe6bf5e7dd327ac2a87528d140/fastremap-1.17.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:95ca7a35fa7f95ac1b88d6d6c3a9ee55a791655d868a3d760d19a9c9d27cb410", size = 753267 },
+    { url = "https://files.pythonhosted.org/packages/7e/02/d5051e61b7b22ec85fc64d47b1e262d527656200f7350b0b4fd810df2bd3/fastremap-1.17.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e04713787a7b63f40e6dd0fe4f45937e6b0b5f0f49fd8c050cc67e7d15df37a6", size = 623206 },
+    { url = "https://files.pythonhosted.org/packages/84/d6/d35557ff17cf6b8069300a885db7c6d8c86bed3da06dd2409be60f77a8f7/fastremap-1.17.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:30198de6976d51dc16d6be596d935e67648bc43ff6ff38b7f8fc587e4138b664", size = 6730123 },
+    { url = "https://files.pythonhosted.org/packages/10/46/cd8942a81f75faa76fe30fb61a8ac3f15287b7604d37a3720db98b8f9488/fastremap-1.17.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c3fa5232862cee10b064778ddaa62bfbf12bf51133dea3dd0b50d56ae14caa06", size = 6888039 },
+    { url = "https://files.pythonhosted.org/packages/aa/18/38d1a374f89004eee2ad2ea25bcfc202c842fac09fcdce78ce0f31cd7f03/fastremap-1.17.2-cp312-cp312-win32.whl", hash = "sha256:e74ea40cfc9e47dec6fc08db0093f73e14b03e0ec270710984a716db005d4746", size = 468008 },
+    { url = "https://files.pythonhosted.org/packages/61/15/f8b0760e069cb2c08fb526f4b1ad94b9c1589b966bd79a8e4c8bd3e25a9b/fastremap-1.17.2-cp312-cp312-win_amd64.whl", hash = "sha256:8625183086221380299aee1c1f81919c45fcbd89a55b961cb22c5a58099630eb", size = 641228 },
+    { url = "https://files.pythonhosted.org/packages/e1/11/b2458864c3712efd122d21f46f6431e869a3caea647445e3dbf881ff45cf/fastremap-1.17.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7e876205c65abd21f76e5fc8860e232687865dad25eccf1ae5ea636fa3ae8e83", size = 751606 },
+    { url = "https://files.pythonhosted.org/packages/0b/c7/1c23bebb70a00eef82ade3a976be92e360ccbdbe302244bcc30b419e6516/fastremap-1.17.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e152a271d55b0958a870118c6d8a1bf952536f11b37ff2217431e14f6be3bae8", size = 622062 },
+    { url = "https://files.pythonhosted.org/packages/dd/11/379573ebd42e8bbb21bab2ea0a7adbc80431bd95a9fcd00847a5b3eb6e9c/fastremap-1.17.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eef8b03dff78862daaf69fb488612b44fe5e9ccc62a53ab65505743dcfeb6304", size = 6719392 },
+    { url = "https://files.pythonhosted.org/packages/8b/f7/344ae611222b58fb8a285c3d89c543e71ebc8400834fd9da56ed1bb0b9bc/fastremap-1.17.2-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:14f78b90f113ac096b09713bb7cceab11654a9641b75c1f6822c3782e6df9e82", size = 6433529 },
+    { url = "https://files.pythonhosted.org/packages/8b/d2/e6d4b739d5665f53fc01f1ad6ea9242660ad3b0cfd76f7cae4cda361029e/fastremap-1.17.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4affb1e0493927785696cbb6bb7584205cad971acde95c21a168ec24e9cc21fc", size = 6809681 },
+    { url = "https://files.pythonhosted.org/packages/b0/5e/14459754f7e7d8a463347d2aa78fb15c41c6b6492173995808b43b0bde68/fastremap-1.17.2-cp313-cp313-win32.whl", hash = "sha256:0949f7b34bed56023d965dfc03bd83c0169639f962a2ab983f462274d7b4d1c7", size = 474741 },
+    { url = "https://files.pythonhosted.org/packages/c7/77/ede857ba946128f3227deb5f353c7d7c020d4467d585c5466e349c5e8b31/fastremap-1.17.2-cp313-cp313-win_amd64.whl", hash = "sha256:0c3e9b07a49ce29c38806d1dfa2cd00d9b7a027b6309b95ef132bfd956b0ffd4", size = 640707 },
+]
+
+[[package]]
 name = "filelock"
 version = "3.18.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0a/10/c23352565a6544bdc5353e0b15fc1c563352101f30e24bf500207a54df9a/filelock-3.18.0.tar.gz", hash = "sha256:adbc88eabb99d2fec8c9c1b229b171f18afa655400173ddc653d5d01501fb9f2", size = 18075 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/36/2a115987e2d8c300a974597416d9de88f2444426de9571f4b59b2cca3acc/filelock-3.18.0-py3-none-any.whl", hash = "sha256:c401f4f8377c4464e6db25fff06205fd89bdd83b65eb0488ed1b160f780e21de", size = 16215 },
+]
+
+[[package]]
+name = "fill-voids"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fastremap" },
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/54/09/b343711386260629ad6b3d2d92bb0c9d45bbc09e1af11ea335b11a659639/fill_voids-2.1.0.tar.gz", hash = "sha256:63f76f7dbdd8cb5f30ea2841a31624eba4612d91211d6ff74d2317f44d449860", size = 3221493 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/f5/9951559902d7c5ae99d4909c830cfa45c498f1b33c3d994dadb8c59950e1/fill_voids-2.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fa743866d35e7686af9cb1f56f4d950514e78a49221c29ef2da2044c614e2939", size = 203237 },
+    { url = "https://files.pythonhosted.org/packages/43/11/9f33d24dd4ce38e5913c6ce7356dafec40496177d582ee81c3cc7ca65a7a/fill_voids-2.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f6aecb6322c813be663e03ef81ee1249e4ff73633f3161aa477d052e8a4de7cd", size = 185804 },
+    { url = "https://files.pythonhosted.org/packages/db/e2/1c5a22043275691813ea8c53f3ad67839f7ab7ed316b34bc24444f93dafe/fill_voids-2.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:527a239eb6a4eb3bff5b082ed348aacc896befc922ebcab87cde9f2d60dd6166", size = 1483092 },
+    { url = "https://files.pythonhosted.org/packages/51/c3/d3f00f6b5ebff5f9e2e88cce6f84e8f0439919066cb09f2e491608a3640e/fill_voids-2.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:700f7b32a4e347977bf3748c7099f36b4f8c241d74c4bafa2ac6082f8660a736", size = 2352571 },
+    { url = "https://files.pythonhosted.org/packages/37/1b/76af886bbafc43fb323e30428d78ae27b34f6f28b7908e09338351b05484/fill_voids-2.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:f58fba5c6c91e19bd0f085a2b3b3fdeb1630520aeb2b3835b483082aea98c81b", size = 174769 },
+    { url = "https://files.pythonhosted.org/packages/70/88/aa943d4ad9c08eb0f710f418086807920cfe23d9af38152b36b2e3733176/fill_voids-2.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:6e65b229607687b9caf951f1840d6c8a471803972804eb9135f42f1435c8cf99", size = 201794 },
+    { url = "https://files.pythonhosted.org/packages/9a/fd/0eba467f4feed477cde474938be81f4f3fd005c848614bbefb4bc9eedf07/fill_voids-2.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a4cb5b90047d6fba68be447d2a044791948785224ccad889ecf79d7b23bee69a", size = 184769 },
+    { url = "https://files.pythonhosted.org/packages/6c/63/84b0a6b9957af6c0c28969893e5ce04eb4d9d09bbf1eb0ea9449514cbb74/fill_voids-2.1.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:de926220ebbe48180fcc3f52ff888b1f3ab15d90bb33bae462d3e356f04e6278", size = 1462545 },
+    { url = "https://files.pythonhosted.org/packages/4c/12/d2d8aba683db8207ff27a0cceebb63f0429e8de94510c8498efd83ebc7df/fill_voids-2.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ad8772158f0cb04e919a2c6cb1affa5c54b44a3387591211ae362373e818d6fa", size = 2311985 },
+    { url = "https://files.pythonhosted.org/packages/57/3b/ef7a2e943a6476d1cb8066a65b119f8c4155829198f615110088172c7fed/fill_voids-2.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:95bed804c6f8db0b5f197551ef1c6eff5cc8a484c4e5b322d0cdde5e1a798cce", size = 174385 },
 ]
 
 [[package]]
@@ -491,6 +563,45 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442 },
+]
+
+[[package]]
+name = "imagecodecs"
+version = "2025.8.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6b/d1/bac78c9bdecbc12bcaa96363dd6d7b358de0b4af512d08c16f6792e7a6ea/imagecodecs-2025.8.2.tar.gz", hash = "sha256:2af272aac90c370326a7e2fffcbbbd32d42de07576959a2a98d60110267dfe6c", size = 9490135 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/2e/b129b2bf95a4332b86452dd93829cb6ab1e203d86a488fc8639e9f08db7d/imagecodecs-2025.8.2-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:32ce9707c85cf90e5fb4d9e076ec78288f0f1c084954376f798397743bc4d4e5", size = 12480416 },
+    { url = "https://files.pythonhosted.org/packages/dc/36/b1d3117c34f5eebfd7a92314042338dce608654173c71b1fb707e416aef5/imagecodecs-2025.8.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7b7cd0c41ea83f249db2f4ee04c7c3f23bd6fbef89a58bdaa7d2bf11421ffc15", size = 10127356 },
+    { url = "https://files.pythonhosted.org/packages/e6/41/9ee8f13c4e3425c1aed0b9c5bca5547b968da20cb60af094fafcb52be05f/imagecodecs-2025.8.2-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10f421048206ffb6763b1eb28f2205535801794e9f2c612bbcc219d14b9e44bc", size = 25765528 },
+    { url = "https://files.pythonhosted.org/packages/d6/1a/f12736807a179a4bd5a26387f2edf00cc3f972139b61f2833f6fbe9b9685/imagecodecs-2025.8.2-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f14a5eb8151e32316028c09212eed1d14334460e8adbbef819c1d8ec6ab7e633", size = 26718026 },
+    { url = "https://files.pythonhosted.org/packages/9c/cd/b0367017443af901279952817900e7f496998fb11de24d91cccdb4fa3dc3/imagecodecs-2025.8.2-cp312-cp312-win32.whl", hash = "sha256:e5cb491fa698d055643d3519bab36a3da8d4144ac759430464e2f75f945f3325", size = 18546766 },
+    { url = "https://files.pythonhosted.org/packages/c4/97/5eb48564f5fdbe3ef83a07ba45d301d45bf85af382a051de34e0a3d6af85/imagecodecs-2025.8.2-cp312-cp312-win_amd64.whl", hash = "sha256:7371169cff1b98f07a983b28fffd2d334cf40a61fce3c876dda930149081bdeb", size = 22674367 },
+    { url = "https://files.pythonhosted.org/packages/2b/b9/a1a70b5d2250937cd747ceff94ddb9cb70d6f1b9fef9f4164d88c63dd3cb/imagecodecs-2025.8.2-cp312-cp312-win_arm64.whl", hash = "sha256:bf0a97cd58810d5d7ecd983332f1f85a0df991080a774f7caadb1add172165d0", size = 17981844 },
+    { url = "https://files.pythonhosted.org/packages/f2/69/77a5c020030dbba1a566264b9201f091534b4b10e9ac5725b7bd40895a8b/imagecodecs-2025.8.2-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:06a1b54847cbf595ed58879936eabdab990f1780b80d03a8d4edb57e61c768b0", size = 12454348 },
+    { url = "https://files.pythonhosted.org/packages/f9/5d/c5dd7f0706dc48d38deefe4cba05ac78236b662a8ef86f9c0cc569b9db96/imagecodecs-2025.8.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:dbf3abd281034e29034b773407c27eff35dd94832a9b6e3c97490db079e3c0a8", size = 10103114 },
+    { url = "https://files.pythonhosted.org/packages/60/40/8b656577120f758ce4b177917b57c76f15e695ff0e63584f641db2063bbe/imagecodecs-2025.8.2-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:248bb2ea3e43690196acdb1dae5aa40213dbd00c47255295d57da80770ceeaa7", size = 25602557 },
+    { url = "https://files.pythonhosted.org/packages/8a/de/6c1cf78cc0ecc45d98a0eb0d8920df7b90719f8643c7ed9b1bb700f95890/imagecodecs-2025.8.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:52230fcd0c331b0167ccd14d7ce764bb780006b65bf69761d8bde6863419fdbf", size = 26544468 },
+    { url = "https://files.pythonhosted.org/packages/51/14/bda4974256e31eca65e33446026c91d54d1124aa59ce042fc326836597ec/imagecodecs-2025.8.2-cp313-cp313-win32.whl", hash = "sha256:151f9e0879ed8a025b19fcffbf4785dacf29002d5fec94d318e84ba154ddd54c", size = 18534480 },
+    { url = "https://files.pythonhosted.org/packages/a6/bb/ada8851ee56ab835562fb96f764f055e16a5d43a81ebc95207f6b2f3c1d4/imagecodecs-2025.8.2-cp313-cp313-win_amd64.whl", hash = "sha256:d167c265caaf36f9f090e55b68a7c0ec4e5b436923cdc047358743f450534154", size = 22662134 },
+    { url = "https://files.pythonhosted.org/packages/7c/b6/687ad4e137fe637213540cf71bf6a3957cc48667ce6d96d6d9dcb8409305/imagecodecs-2025.8.2-cp313-cp313-win_arm64.whl", hash = "sha256:37199e19d61c7a6c0cf901859d7a81c4449d18047a15ca9d2ebe17176c8d1b69", size = 17968181 },
+    { url = "https://files.pythonhosted.org/packages/63/5f/2be51d6ea6e6cae13d8d4ce77d5076ef72e492f670368bb193db35e146ce/imagecodecs-2025.8.2-cp314-cp314-macosx_10_14_x86_64.whl", hash = "sha256:7a3c89b5f5c946d5649892e15b5c89aeca357d048331c3a4ae89009320d2704a", size = 12447596 },
+    { url = "https://files.pythonhosted.org/packages/6e/75/d9cd579b1fd5fdef5742567236adb49df15beaf8f66219412f21fb86a64c/imagecodecs-2025.8.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:3a4d2249e4d25a57da7da336c68efc72a7e15f9271dc6c13c322947f30383b8e", size = 10107274 },
+    { url = "https://files.pythonhosted.org/packages/57/46/011e41f99f2301091f902afd917a4a8079056510dfcb8b8529d96e4232c8/imagecodecs-2025.8.2-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:31ebfca1bd01c6e4db25c0a91301ddc9aeca1dc63642db689543a9700a5869e8", size = 25579702 },
+    { url = "https://files.pythonhosted.org/packages/bd/9b/b2d38a3902b2a61cfdbe1bca7aa939b77e32349d00aba7a4014d1dfd8cb9/imagecodecs-2025.8.2-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:be84bd8f3cf1552efc92f2465af5ab40a14a788d48482ef3a702e9dae5f4cd0b", size = 26372160 },
+    { url = "https://files.pythonhosted.org/packages/c2/96/a22ce5b43a93d12b21f2ec9e374cd4a7edf9347630c7ed90bef7c4ca9f5d/imagecodecs-2025.8.2-cp314-cp314-win32.whl", hash = "sha256:ce57af27547c42dfb888562a1a22dc51a6103c20b3fb69ac4c26121acc741ade", size = 18802212 },
+    { url = "https://files.pythonhosted.org/packages/b3/0c/d364bff2ffb8f2864e9f7fa6dd05b57c25a4c341ba1e2f08b3dea1dc8a6d/imagecodecs-2025.8.2-cp314-cp314-win_amd64.whl", hash = "sha256:b93d77293c0aa9e661d42f3203b13ea135d5bf9f0936fbbe90780ed1c67322d3", size = 23052776 },
+    { url = "https://files.pythonhosted.org/packages/7d/4b/54d1e3a2b9d11c8a875c98b543dc5527c259c174b05987b1e79ccfc107b9/imagecodecs-2025.8.2-cp314-cp314-win_arm64.whl", hash = "sha256:d7a53983d4df035761dc652e44c912092bddc5b115d6f5f612df301ce94fcd55", size = 18374009 },
+    { url = "https://files.pythonhosted.org/packages/ae/8f/c614d151d577c17f38bb8ba9388f56eaccc5c3708b3109ed103209350bc8/imagecodecs-2025.8.2-cp314-cp314t-macosx_10_14_x86_64.whl", hash = "sha256:9e2b138c2826cf58d4088513fe61bf2311d6206e0eb865a37cd27749812bcc2a", size = 12582934 },
+    { url = "https://files.pythonhosted.org/packages/cf/d2/9129c759a5d11c0c0f119fe08871823a623bb382c2996486db5442c3d61b/imagecodecs-2025.8.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:fa4750e23d69c95b99eff991ca3f28176b77b2e9ccf14eb326942afa4258d349", size = 10277782 },
+    { url = "https://files.pythonhosted.org/packages/31/39/838c2fc76e9d775b385b6d11b7882d162c895bd1c62aaf57143c79956c7f/imagecodecs-2025.8.2-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2ca3bb477946836af844dfe89d2bfb21c69e2e08904560f927dbb4298cfb76c9", size = 26631262 },
+    { url = "https://files.pythonhosted.org/packages/d7/38/c3f0ab9374b1b74c125ac3e77a8ee84b9a1e9eb7429dca0f026a792d02ed/imagecodecs-2025.8.2-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dd14eb5626cf7b307f9442da130c2a5340cd088718b71d35ce7389409b2e5341", size = 27053693 },
+    { url = "https://files.pythonhosted.org/packages/df/00/88399944e570369c39e626020200136ae20d9fcbb439e83ec0f25d301721/imagecodecs-2025.8.2-cp314-cp314t-win32.whl", hash = "sha256:4d8378e3068b12abc4cd9dbde8867ce80dad89b9f11a7bd24321c139eaea30aa", size = 19110281 },
+    { url = "https://files.pythonhosted.org/packages/a1/ec/bbeb61bb3b8c6853c74c501e787cc5be025454be8679fda385b3ee451c8b/imagecodecs-2025.8.2-cp314-cp314t-win_amd64.whl", hash = "sha256:4d1002282afc6b89616915e9741fa8bbd283e214a268f03b14a74acb43aad451", size = 23430830 },
+    { url = "https://files.pythonhosted.org/packages/d0/c0/93445b41eb2063414ebb443aa93bccaff2868252a8c55c8c0ea72a7be96a/imagecodecs-2025.8.2-cp314-cp314t-win_arm64.whl", hash = "sha256:f8bb58c7da65f93fee53d4b279d4030db2804b97a42c5135abc82f02ebfb4c3a", size = 18497460 },
 ]
 
 [[package]]
@@ -990,6 +1101,15 @@ wheels = [
 ]
 
 [[package]]
+name = "natsort"
+version = "8.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/a9/a0c57aee75f77794adaf35322f8b6404cbd0f89ad45c87197a937764b7d0/natsort-8.4.0.tar.gz", hash = "sha256:45312c4a0e5507593da193dedd04abb1469253b601ecaf63445ad80f0a1ea581", size = 76575 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/82/7a9d0550484a62c6da82858ee9419f3dd1ccc9aa1c26a1e43da3ecd20b0d/natsort-8.4.0-py3-none-any.whl", hash = "sha256:4732914fb471f56b5cce04d7bae6f164a592c7712e1c85f9ef585e197299521c", size = 38268 },
+]
+
+[[package]]
 name = "nbclient"
 version = "0.10.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1275,6 +1395,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/cb/49/f9d313e03eefb4a7f81d1edba8493a4a40ef622bb48bab2f03600ee1ad86/ome_types-0.6.1.tar.gz", hash = "sha256:49e7a79ac90f8e4c33392f285491cb2577d41f2583bb879307c4f5ba9436e721", size = 121623 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/93/c7/5d63372b13bfe9eaff26d540e7a1d2da5f0b4d82a5cbe634b638f1df61a3/ome_types-0.6.1-py3-none-any.whl", hash = "sha256:128f9bd5f52212cf37dad087ee4a7df939ccbf40a328d986e0bf9ac564abd4e9", size = 245142 },
+]
+
+[[package]]
+name = "opencv-python-headless"
+version = "4.12.0.88"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a4/63/6861102ec149c3cd298f4d1ea7ce9d6adbc7529221606ff1dab991a19adb/opencv-python-headless-4.12.0.88.tar.gz", hash = "sha256:cfdc017ddf2e59b6c2f53bc12d74b6b0be7ded4ec59083ea70763921af2b6c09", size = 95379675 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/7d/414e243c5c8216a5277afd104a319cc1291c5e23f5eeef512db5629ee7f4/opencv_python_headless-4.12.0.88-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:1e58d664809b3350c1123484dd441e1667cd7bed3086db1b9ea1b6f6cb20b50e", size = 37877864 },
+    { url = "https://files.pythonhosted.org/packages/05/14/7e162714beed1cd5e7b5eb66fcbcba2f065c51b1d9da2463024c84d2f7c0/opencv_python_headless-4.12.0.88-cp37-abi3-macosx_13_0_x86_64.whl", hash = "sha256:365bb2e486b50feffc2d07a405b953a8f3e8eaa63865bc650034e5c71e7a5154", size = 57326608 },
+    { url = "https://files.pythonhosted.org/packages/69/4e/116720df7f1f7f3b59abc608ca30fbec9d2b3ae810afe4e4d26483d9dfa0/opencv_python_headless-4.12.0.88-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:aeb4b13ecb8b4a0beb2668ea07928160ea7c2cd2d9b5ef571bbee6bafe9cc8d0", size = 33145800 },
+    { url = "https://files.pythonhosted.org/packages/89/53/e19c21e0c4eb1275c3e2c97b081103b6dfb3938172264d283a519bf728b9/opencv_python_headless-4.12.0.88-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:236c8df54a90f4d02076e6f9c1cc763d794542e886c576a6fee46ec8ff75a7a9", size = 54023419 },
+    { url = "https://files.pythonhosted.org/packages/bf/9c/a76fd5414de6ec9f21f763a600058a0c3e290053cea87e0275692b1375c0/opencv_python_headless-4.12.0.88-cp37-abi3-win32.whl", hash = "sha256:fde2cf5c51e4def5f2132d78e0c08f9c14783cd67356922182c6845b9af87dbd", size = 30225230 },
+    { url = "https://files.pythonhosted.org/packages/f2/35/0858e9e71b36948eafbc5e835874b63e515179dc3b742cbe3d76bc683439/opencv_python_headless-4.12.0.88-cp37-abi3-win_amd64.whl", hash = "sha256:86b413bdd6c6bf497832e346cd5371995de148e579b9774f8eba686dee3f5528", size = 38923559 },
 ]
 
 [[package]]
@@ -1787,6 +1924,18 @@ wheels = [
 ]
 
 [[package]]
+name = "roifile"
+version = "2025.5.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/ee/8ab570959011aac7d5705b7c284ab90734aed297672711444e21c11ab4d0/roifile-2025.5.10.tar.gz", hash = "sha256:8e5d1f799695ac59f52d4d62bb9016de74ef2493b4d83e24ce7fb25e19f53cce", size = 18768 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/9b/f689742c06f377e33090d78e370d013e7e062ab8ac407f03f1105ddfc934/roifile-2025.5.10-py3-none-any.whl", hash = "sha256:92ef64a775167542cd98c4beb7c5f867412c572d1a111f03ee0fede7fdf64155", size = 17557 },
+]
+
+[[package]]
 name = "rpds-py"
 version = "0.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2002,6 +2151,15 @@ wheels = [
 ]
 
 [[package]]
+name = "segment-anything"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/88/7725f418f2bb4a7ac2e5e8295fbbca2900c70c8fe5ba48b3aff5788af9a2/segment_anything-1.0.tar.gz", hash = "sha256:ed0c9f6fb07bbef9c6238a7028a13c8272f1ba6b6305ca73e3e064266503736b", size = 31191 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/77/8e0c16abf151a1dd076b562febc0da2ecf1132b0b41826087af96f101f42/segment_anything-1.0-py3-none-any.whl", hash = "sha256:86f67d417a915823c3302098effe9008b688945772517310956bb49de0e7f02e", size = 36560 },
+]
+
+[[package]]
 name = "send2trash"
 version = "1.8.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2172,6 +2330,30 @@ wheels = [
 ]
 
 [[package]]
+name = "torchvision"
+version = "0.23.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "torch" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/1d/0ea0b34bde92a86d42620f29baa6dcbb5c2fc85990316df5cb8f7abb8ea2/torchvision-0.23.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e0e2c04a91403e8dd3af9756c6a024a1d9c0ed9c0d592a8314ded8f4fe30d440", size = 1856885 },
+    { url = "https://files.pythonhosted.org/packages/e2/00/2f6454decc0cd67158c7890364e446aad4b91797087a57a78e72e1a8f8bc/torchvision-0.23.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:6dd7c4d329a0e03157803031bc856220c6155ef08c26d4f5bbac938acecf0948", size = 2396614 },
+    { url = "https://files.pythonhosted.org/packages/e4/b5/3e580dcbc16f39a324f3dd71b90edbf02a42548ad44d2b4893cc92b1194b/torchvision-0.23.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:4e7d31c43bc7cbecbb1a5652ac0106b436aa66e26437585fc2c4b2cf04d6014c", size = 8627108 },
+    { url = "https://files.pythonhosted.org/packages/82/c1/c2fe6d61e110a8d0de2f94276899a2324a8f1e6aee559eb6b4629ab27466/torchvision-0.23.0-cp312-cp312-win_amd64.whl", hash = "sha256:a2e45272abe7b8bf0d06c405e78521b5757be1bd0ed7e5cd78120f7fdd4cbf35", size = 1600723 },
+    { url = "https://files.pythonhosted.org/packages/91/37/45a5b9407a7900f71d61b2b2f62db4b7c632debca397f205fdcacb502780/torchvision-0.23.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1c37e325e09a184b730c3ef51424f383ec5745378dc0eca244520aca29722600", size = 1856886 },
+    { url = "https://files.pythonhosted.org/packages/ac/da/a06c60fc84fc849377cf035d3b3e9a1c896d52dbad493b963c0f1cdd74d0/torchvision-0.23.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:2f7fd6c15f3697e80627b77934f77705f3bc0e98278b989b2655de01f6903e1d", size = 2353112 },
+    { url = "https://files.pythonhosted.org/packages/a0/27/5ce65ba5c9d3b7d2ccdd79892ab86a2f87ac2ca6638f04bb0280321f1a9c/torchvision-0.23.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:a76fafe113b2977be3a21bf78f115438c1f88631d7a87203acb3dd6ae55889e6", size = 8627658 },
+    { url = "https://files.pythonhosted.org/packages/1f/e4/028a27b60aa578a2fa99d9d7334ff1871bb17008693ea055a2fdee96da0d/torchvision-0.23.0-cp313-cp313-win_amd64.whl", hash = "sha256:07d069cb29691ff566e3b7f11f20d91044f079e1dbdc9d72e0655899a9b06938", size = 1600749 },
+    { url = "https://files.pythonhosted.org/packages/05/35/72f91ad9ac7c19a849dedf083d347dc1123f0adeb401f53974f84f1d04c8/torchvision-0.23.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:2df618e1143805a7673aaf82cb5720dd9112d4e771983156aaf2ffff692eebf9", size = 2047192 },
+    { url = "https://files.pythonhosted.org/packages/1d/9d/406cea60a9eb9882145bcd62a184ee61e823e8e1d550cdc3c3ea866a9445/torchvision-0.23.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:2a3299d2b1d5a7aed2d3b6ffb69c672ca8830671967eb1cee1497bacd82fe47b", size = 2359295 },
+    { url = "https://files.pythonhosted.org/packages/2b/f4/34662f71a70fa1e59de99772142f22257ca750de05ccb400b8d2e3809c1d/torchvision-0.23.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:76bc4c0b63d5114aa81281390f8472a12a6a35ce9906e67ea6044e5af4cab60c", size = 8800474 },
+    { url = "https://files.pythonhosted.org/packages/6e/f5/b5a2d841a8d228b5dbda6d524704408e19e7ca6b7bb0f24490e081da1fa1/torchvision-0.23.0-cp313-cp313t-win_amd64.whl", hash = "sha256:b9e2dabf0da9c8aa9ea241afb63a8f3e98489e706b22ac3f30416a1be377153b", size = 1527667 },
+]
+
+[[package]]
 name = "tornado"
 version = "6.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2188,6 +2370,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/18/e3f902a1d21f14035b5bc6246a8c0f51e0eef562ace3a2cea403c1fb7021/tornado-6.5.1-cp39-abi3-win32.whl", hash = "sha256:e0a36e1bc684dca10b1aa75a31df8bdfed656831489bc1e6a6ebed05dc1ec365", size = 444396 },
     { url = "https://files.pythonhosted.org/packages/7b/09/6526e32bf1049ee7de3bebba81572673b19a2a8541f795d887e92af1a8bc/tornado-6.5.1-cp39-abi3-win_amd64.whl", hash = "sha256:908e7d64567cecd4c2b458075589a775063453aeb1d2a1853eedb806922f568b", size = 444840 },
     { url = "https://files.pythonhosted.org/packages/55/a7/535c44c7bea4578e48281d83c615219f3ab19e6abc67625ef637c73987be/tornado-6.5.1-cp39-abi3-win_arm64.whl", hash = "sha256:02420a0eb7bf617257b9935e2b754d1b63897525d8a289c9d65690d580b4dcf7", size = 443596 },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "platform_system == 'Windows'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Major refactoring of SegmentationModel to use Cellpose-SAM (v4.x) with improved architecture and test coverage.

Unfortunately, Cellpose-SAM can only be run on one image at a time. Kind of unknown if Cellpose v3 was actually only being run on one image at a time or not... either way batch processing is now significantly slower for the price of accuracy:
https://www.biorxiv.org/content/10.1101/2025.04.28.651001v1

Practically speaking, 16 grayscale 1024x1024 images previously took ~30 seconds to segment, and now takes ~80 seconds.

### Changes

**Model Architecture:**
- Migrated from CellposeDenoiseModel to CellposeModel for Cellpose-SAM compatibility
- Replaced legacy parameters (model_type, restore_type, channels) with Cellpose-SAM parameters

**Parameter Validation:**
- Added validation for cell_diameter_px, flow_threshold, and cellprob_threshold
- Automatic device assignment if not specified

**API Improvements:**
- Simplified run() method with batch processing support
- Better parameter naming (cell_diameter_px vs diameter)
- Support for num_iterations and flexible **cellpose_kwargs

### Testing

- Mocked integration tests for the run() method
- Edge case validation and error handling tests
- Ran real integration tests on existing datasets (too large to include) to validate model performance

🤖 Generated with https://claude.ai/code
💁🏻‍♂️ Edited for humility

## PR checklist

- [x] Describe the changes you've made.
- [x] Describe any tests you have conducted to confirm that your changes behave as expected.
- [x] If you've added new software dependencies, make sure that those dependencies are included in the `pyproject.toml` and `uv.lock` files.
- [x] If you've added new functionality, make sure that the documentation is updated accordingly.
