### PR TITLE
Improve ND2 metadata parsing for timelapse frame interval and duration

### DIFF
--- a/src/arcadia_microscopy_tools/tests/data/known-metadata.yml
+++ b/src/arcadia_microscopy_tools/tests/data/known-metadata.yml
@@ -7,6 +7,7 @@ example-multichannel.nd2:
       - 0.323390342594048
       - 0.323390342594048
     z_step_size_um: 1.0
+    objective: Plan Apo λ 20x
     magnification: 20.0
     numerical_aperture: 0.75
     zoom: 1.0
@@ -21,6 +22,7 @@ example-multichannel.nd2:
      - 0.323390342594048
      - 0.323390342594048
     z_step_size_um: 1.0
+    objective: Plan Apo λ 20x
     magnification: 20.0
     numerical_aperture: 0.75
     zoom: 1.0
@@ -35,6 +37,7 @@ example-multichannel.nd2:
       - 0.323390342594048
       - 0.323390342594048
     z_step_size_um: 1.0
+    objective: Plan Apo λ 20x
     magnification: 20.0
     numerical_aperture: 0.75
     zoom: 1.0
@@ -49,6 +52,7 @@ example-multichannel.nd2:
       - 0.323390342594048
       - 0.323390342594048
     z_step_size_um: 1.0
+    objective: Plan Apo λ 20x
     magnification: 20.0
     numerical_aperture: 0.75
     zoom: 1.0
@@ -65,6 +69,7 @@ example-timelapse.nd2:
       - 0.325
       - 0.325
     z_step_size_um: 1.0
+    objective: PLAN APO λD 40x OFN25 DIC N2
     magnification: 40.0
     numerical_aperture: 0.95
     zoom: 1.0
@@ -81,6 +86,7 @@ example-zstack.nd2:
       - 0.323390342594048
       - 0.323390342594048
     z_step_size_um: 6.0
+    objective: Plan Apo λ 20x
     magnification: 20.0
     numerical_aperture: 0.75
     zoom: 1.0

--- a/src/arcadia_microscopy_tools/tests/data/known-metadata.yml
+++ b/src/arcadia_microscopy_tools/tests/data/known-metadata.yml
@@ -75,6 +75,7 @@ example-timelapse.nd2:
     zoom: 1.0
     binning: 2x2
     exposure_time_ms: 500.0
+    duration_s: 60
     laser_power_pct: 95.7
 
 example-zstack.nd2:

--- a/src/arcadia_microscopy_tools/tests/data/known-metadata.yml
+++ b/src/arcadia_microscopy_tools/tests/data/known-metadata.yml
@@ -7,7 +7,6 @@ example-multichannel.nd2:
       - 0.323390342594048
       - 0.323390342594048
     z_step_size_um: 1.0
-    objective: Plan Apo λ 20x
     magnification: 20.0
     numerical_aperture: 0.75
     zoom: 1.0
@@ -22,7 +21,6 @@ example-multichannel.nd2:
      - 0.323390342594048
      - 0.323390342594048
     z_step_size_um: 1.0
-    objective: Plan Apo λ 20x
     magnification: 20.0
     numerical_aperture: 0.75
     zoom: 1.0
@@ -37,7 +35,6 @@ example-multichannel.nd2:
       - 0.323390342594048
       - 0.323390342594048
     z_step_size_um: 1.0
-    objective: Plan Apo λ 20x
     magnification: 20.0
     numerical_aperture: 0.75
     zoom: 1.0
@@ -52,7 +49,6 @@ example-multichannel.nd2:
       - 0.323390342594048
       - 0.323390342594048
     z_step_size_um: 1.0
-    objective: Plan Apo λ 20x
     magnification: 20.0
     numerical_aperture: 0.75
     zoom: 1.0
@@ -69,7 +65,6 @@ example-timelapse.nd2:
       - 0.325
       - 0.325
     z_step_size_um: 1.0
-    objective: PLAN APO λD 40x OFN25 DIC N2
     magnification: 40.0
     numerical_aperture: 0.95
     zoom: 1.0
@@ -87,7 +82,6 @@ example-zstack.nd2:
       - 0.323390342594048
       - 0.323390342594048
     z_step_size_um: 6.0
-    objective: Plan Apo λ 20x
     magnification: 20.0
     numerical_aperture: 0.75
     zoom: 1.0


### PR DESCRIPTION
<!--
Many thanks for contributing to Arcadia-Science/arcadia-microscopy-tools! 🎉

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).
-->

## Summary

Mostly improved ND2 file parsing. Motivated by realizing that exposure time =/= period between frames in a time lapse, and that this was problematic. Now parses for both the period [ms] (frame interval) as well as duration [s] although the ND2 metadata will only output one or the other.

**All changes:**

- add dimensions as an ImageMetadata attribute
- add parsing for dimensions from ND2 files
- add parsing for microscope objective
- add parsing for period (frame interval)
- add parsing for duration (total time)
- clean up parsing for laser power, time based properties
- add example metadata for 'sample' and 'plane' sections of text_info

## PR checklist

- [x] Describe the changes you've made.
