### PR TITLE
Make PyPI publish idempotent on re-runs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,4 +24,6 @@ jobs:
       - name: Build
         run: uv build
       - name: Publish
-        run: uv publish
+        # --check-url lets re-runs (e.g. after a squash-merge retag) skip files
+        # that are already on PyPI instead of failing with "File already exists".
+        run: uv publish --check-url https://pypi.org/simple/arcadia-microscopy-tools/


### PR DESCRIPTION
## Summary

The `v0.4.0` Publish run failed with `400 File already exists` because the tag was pushed twice (once at the pre-merge branch tip, then again after the squash-merge retag). PyPI versions are immutable, so the second upload is rejected.

This adds `--check-url` to `uv publish` so re-runs skip files already present on the index instead of failing the job. No effect on first-time publishes.

## Test plan
- [ ] Confirm the Publish job is green on the next tag push (or re-run), skipping already-uploaded files rather than erroring

Made with [Cursor](https://cursor.com)