### PR TITLE
Consolidate optional-dependency extras and ignore local test data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ venv/
 
 # OS
 .DS_Store
+
+# Large/local microscopy test files
+src/arcadia_microscopy_tools/tests/data/local/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,17 +22,16 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+compute = [
+    "modal>=1.3.0",
+]
 segmentation = [
     "cellpose>=4.0.8",
     "torch>=2.7.1",
     "tqdm>=4.67.1",
 ]
-compute = [
-    "modal",
-]
 all = [
-    "cellpose>=4.0.8",
-    "modal",
+    "arcadia-microscopy-tools[compute,segmentation]",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -172,6 +172,8 @@ dependencies = [
 all = [
     { name = "cellpose" },
     { name = "modal" },
+    { name = "torch" },
+    { name = "tqdm" },
 ]
 compute = [
     { name = "modal" },
@@ -192,14 +194,13 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "arcadia-microscopy-tools", extras = ["compute", "segmentation"], marker = "extra == 'all'" },
     { name = "arcadia-pycolor", specifier = ">=0.6.5" },
-    { name = "cellpose", marker = "extra == 'all'", specifier = ">=4.0.8" },
     { name = "cellpose", marker = "extra == 'segmentation'", specifier = ">=4.0.8" },
     { name = "colour-science", specifier = ">=0.4.7" },
     { name = "liffile", specifier = ">=2025.12.12" },
     { name = "matplotlib", specifier = ">=3.10.3" },
-    { name = "modal", marker = "extra == 'all'" },
-    { name = "modal", marker = "extra == 'compute'" },
+    { name = "modal", marker = "extra == 'compute'", specifier = ">=1.3.0" },
     { name = "nd2", specifier = ">=0.10.3" },
     { name = "numpy", specifier = ">=2.4.1" },
     { name = "pandas", specifier = ">=2.3.3" },
@@ -208,7 +209,7 @@ requires-dist = [
     { name = "torch", marker = "extra == 'segmentation'", specifier = ">=2.7.1" },
     { name = "tqdm", marker = "extra == 'segmentation'", specifier = ">=4.67.1" },
 ]
-provides-extras = ["segmentation", "compute", "all"]
+provides-extras = ["compute", "segmentation", "all"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

- Define the `all` extra as a self-reference to `[compute,segmentation]` so it stays in sync. Previously `all` listed `cellpose` and `modal` directly but was missing `torch` and `tqdm` (required by `segmentation`), so it was incomplete.
- Pin the `modal` floor to `>=1.3.0`, consistent with the other pinned extras.
- Regenerate `uv.lock` to match.
- Add `.gitignore` entry for `src/arcadia_microscopy_tools/tests/data/local/` to keep large/local microscopy test files out of the repo.

## PR checklist

- [ ] Tag the issue(s) or milestones this PR fixes (e.g. `Fixes #123, Resolves #456`).
- [x] Describe the changes you've made.
- [ ] Describe any tests you have conducted to confirm that your changes behave as expected.
- [x] If you've added new software dependencies, make sure that those dependencies are included in the `pyproject.toml` and `uv.lock` files.
- [ ] If you've added new functionality, make sure that the documentation is updated accordingly.
- [x] If you encountered bugs or features that you won't address, but should be addressed eventually, create new issues for them.

Made with [Cursor](https://cursor.com)